### PR TITLE
Update modals to increase readability on High-Contrast Theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [client] Use correct casing for user id prop for web chat in PR [#1374](https://github.com/Microsoft/BotFramework-Emulator/pull/1374)
 - [luis / qnamaker] Addressed npm security vulnerabilities in luis & qnamaker extensions in PR [#1371](https://github.com/Microsoft/BotFramework-Emulator/pull/1371)
 - [main] Fixed issue where current user id was out of sync between client and main in PR [#1378](https://github.com/Microsoft/BotFramework-Emulator/pull/1378)
+- [client] Fixed issue where modals were very hard to read on high contrast theme PR [#1402](https://github.com/Microsoft/BotFramework-Emulator/pull/1402)
 
 ## Removed
 - [telemetry] Disabled telemetry and the ability to opt-in to collect usage data in PR [#1375](https://github.com/Microsoft/BotFramework-Emulator/pull/1375)

--- a/packages/app/client/src/ui/styles/themes/high-contrast.css
+++ b/packages/app/client/src/ui/styles/themes/high-contrast.css
@@ -84,7 +84,7 @@ html {
   --input-label-color-disabled: var(--neutral-7);
   --input-border: 1px solid #C8C8C8;
   --input-border-focus: var(--p-button-border-focus);
-  --input-border-error: 1px solid #D02E00;
+  --input-border-error: 1px solid #F38518;
   --input-placeholder-color: var(--neutral-7);
   --input-border-disabled: 1px solid var(--neutral-7);
 
@@ -220,6 +220,8 @@ html {
 .dialog {
   --dialog-bg: var(--neutral-16);
   color: var(--neutral-4) !important;
+  --error-text: #F38518 !important;
+
 }
 
 .dialog .ms-Button-label {

--- a/packages/app/client/src/ui/styles/themes/high-contrast.css
+++ b/packages/app/client/src/ui/styles/themes/high-contrast.css
@@ -218,8 +218,10 @@ html {
 }
 
 .dialog {
-  --dialog-bg: var(--neutral-1);
+  --dialog-bg: var(--neutral-16);
+  color: var(--neutral-4) !important;
 }
+
 .dialog .ms-Button-label {
   color: var(--neutral-15);
 }


### PR DESCRIPTION
Fixes issue #

### Changes made
- Update `.dialog`  _color_ and _bg-color_ of the high-contrast theme to match the theme's palette.

![imagen](https://user-images.githubusercontent.com/27219455/55173623-cd9c7480-515a-11e9-8c60-6f5cf2a86650.png)

![imagen](https://user-images.githubusercontent.com/22912283/55183032-b3b85d00-516d-11e9-95de-7908f541c3ed.png)

![imagen](https://user-images.githubusercontent.com/22912283/55183696-2d047f80-516f-11e9-8202-d44f59176b51.png)
