### PR TITLE
Save transcript does not open if bot opened via URL

### DIFF
--- a/packages/app/client/src/data/sagas/botSagas.ts
+++ b/packages/app/client/src/data/sagas/botSagas.ts
@@ -72,7 +72,7 @@ export function* openBotViaUrl(action: BotAction<Partial<StartConversationParams
     action.payload.user = users.usersById[users.currentUserId];
   }
 
-  yield call([ActiveBotHelper, ActiveBotHelper.confirmAndOpenBotFromURL]), action.payload.transcriptPath;
+  yield call([ActiveBotHelper, ActiveBotHelper.confirmAndOpenBotFromURL], action.payload.transcriptPath);
 
   const response = yield ConversationService.startConversation(serverUrl, action.payload);
   if (!response.ok) {

--- a/packages/app/client/src/data/sagas/botSagas.ts
+++ b/packages/app/client/src/data/sagas/botSagas.ts
@@ -71,6 +71,9 @@ export function* openBotViaUrl(action: BotAction<Partial<StartConversationParams
     const users: UserSettings = yield select((state: RootState) => state.clientAwareSettings.users);
     action.payload.user = users.usersById[users.currentUserId];
   }
+
+  yield call([ActiveBotHelper, ActiveBotHelper.confirmAndOpenBotFromURL]);
+
   const response = yield ConversationService.startConversation(serverUrl, action.payload);
   if (!response.ok) {
     const errorNotification = beginAdd(

--- a/packages/app/client/src/data/sagas/botSagas.ts
+++ b/packages/app/client/src/data/sagas/botSagas.ts
@@ -72,7 +72,7 @@ export function* openBotViaUrl(action: BotAction<Partial<StartConversationParams
     action.payload.user = users.usersById[users.currentUserId];
   }
 
-  yield call([ActiveBotHelper, ActiveBotHelper.confirmAndOpenBotFromURL]);
+  yield call([ActiveBotHelper, ActiveBotHelper.confirmAndOpenBotFromURL]), action.payload.transcriptPath;
 
   const response = yield ConversationService.startConversation(serverUrl, action.payload);
   if (!response.ok) {

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
@@ -48,6 +48,7 @@ export interface OpenBotDialogState {
   botUrl?: string;
   appId?: string;
   appPassword?: string;
+  botTranscriptPath?: string;
 }
 
 enum ValidationResult {
@@ -58,7 +59,7 @@ enum ValidationResult {
 }
 
 export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogState> {
-  public state = { botUrl: '', appId: '', appPassword: '' };
+  public state = { botUrl: '', appId: '', appPassword: '', botTranscriptPath: '' };
 
   private static getErrorMessage(result: ValidationResult): string {
     if (result === ValidationResult.Empty || result === ValidationResult.Valid) {
@@ -83,11 +84,12 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
   }
 
   public render(): ReactNode {
-    const { botUrl, appId, appPassword } = this.state;
+    const { botUrl, appId, appPassword, botTranscriptPath } = this.state;
     const validationResult = OpenBotDialog.validateEndpoint(botUrl);
     const errorMessage = OpenBotDialog.getErrorMessage(validationResult);
-    const shouldBeDisabled =
+    const buttonShouldBeDisabled =
       validationResult === ValidationResult.Invalid || validationResult === ValidationResult.Empty;
+    // const fieldShouldBeDisabled = !(botUrl.startsWith('http'));
     return (
       <Dialog cancel={this.props.onDialogCancel} className={openBotStyles.themeOverrides} title="Open a bot">
         <form onSubmit={this.onSubmit}>
@@ -108,6 +110,27 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
                 accept=".bot"
                 className={openBotStyles.fileInput}
                 name="botUrl"
+                onChange={this.onInputChange}
+                type="file"
+              />
+            </PrimaryButton>
+          </TextField>
+          <TextField
+            autoFocus={true}
+            name="botTranscriptPath"
+            inputContainerClassName={openBotStyles.inputContainer}
+            label="Path to save dialogs or transcripts when using URL"
+            onChange={this.onInputChange}
+            onFocus={this.onFocus}
+            placeholder="Path to save dialogs or transcripts"
+            value={botTranscriptPath}
+          >
+            <PrimaryButton className={openBotStyles.browseButton}>
+              Browse
+              <input
+                accept=".bot"
+                className={openBotStyles.fileInput}
+                name="botTranscriptPath"
                 onChange={this.onInputChange}
                 type="file"
               />
@@ -134,7 +157,7 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
           </Row>
           <DialogFooter>
             <DefaultButton onClick={this.props.onDialogCancel}>Cancel</DefaultButton>
-            <PrimaryButton type="submit" disabled={shouldBeDisabled}>
+            <PrimaryButton type="submit" disabled={buttonShouldBeDisabled}>
               Connect
             </PrimaryButton>
           </DialogFooter>

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
@@ -83,19 +83,32 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
     return endpoint.endsWith('.bot') ? ValidationResult.Valid : ValidationResult.Invalid;
   }
 
-  private static validatePath(path: string): ValidationResult {
-    return path ? ValidationResult.Valid : ValidationResult.Invalid;
+  private static validateEndpointResult(urlValidationResult: ValidationResult) {
+    return (
+      urlValidationResult === ValidationResult.Empty ||
+      urlValidationResult === ValidationResult.Invalid ||
+      urlValidationResult === ValidationResult.RouteMissing
+    );
+  }
+
+  private static disableButton(botUrl, botTranscriptPath) {
+    if (OpenBotDialog.validateEndpointResult(this.validateEndpoint(botUrl))) {
+      return true;
+    } else {
+      if (botTranscriptPath.length == 0 && botUrl.startsWith('http')) {
+        return true;
+      } else {
+        return false;
+      }
+    }
   }
 
   public render(): ReactNode {
     const { botUrl, appId, appPassword, botTranscriptPath } = this.state;
-    const urlValidationResult = OpenBotDialog.validateEndpoint(botUrl);
-    const pathValidationResult = OpenBotDialog.validatePath(botTranscriptPath);
-    const errorMessage = OpenBotDialog.getErrorMessage(urlValidationResult);
-    const buttonShouldBeDisabled =
-      (urlValidationResult === ValidationResult.Invalid || urlValidationResult === ValidationResult.Empty) &&
-      pathValidationResult === ValidationResult.Invalid;
+
+    const errorMessage = OpenBotDialog.getErrorMessage(OpenBotDialog.validateEndpoint(botUrl));
     const fieldShouldBeDisabled = !botUrl.startsWith('http');
+    const buttonShouldBeDisabled = OpenBotDialog.disableButton(botUrl, botTranscriptPath);
     return (
       <Dialog cancel={this.props.onDialogCancel} className={openBotStyles.themeOverrides} title="Open a bot">
         <form onSubmit={this.onSubmit}>
@@ -123,6 +136,7 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
           </TextField>
           <TextField
             autoFocus={true}
+            disabled={fieldShouldBeDisabled}
             name="botTranscriptPath"
             inputContainerClassName={openBotStyles.inputContainer}
             label="Path to save dialogs or transcripts when using URL"
@@ -130,19 +144,8 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
             onFocus={this.onFocus}
             placeholder="Path to save dialogs or transcripts"
             value={botTranscriptPath}
-            disabled={fieldShouldBeDisabled}
-          >
-            <PrimaryButton className={openBotStyles.browseButton} disabled={fieldShouldBeDisabled}>
-              Browse
-              <input
-                accept=".bot"
-                className={openBotStyles.fileInput}
-                name="botTranscriptPath"
-                onChange={this.onInputChange}
-                type="file"
-              />
-            </PrimaryButton>
-          </TextField>
+            required={!fieldShouldBeDisabled}
+          />
           <Row className={openBotStyles.multiInputRow}>
             <TextField
               inputContainerClassName={openBotStyles.inputContainerRow}

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
@@ -83,13 +83,19 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
     return endpoint.endsWith('.bot') ? ValidationResult.Valid : ValidationResult.Invalid;
   }
 
+  private static validatePath(path: string): ValidationResult {
+    return path ? ValidationResult.Valid : ValidationResult.Invalid;
+  }
+
   public render(): ReactNode {
     const { botUrl, appId, appPassword, botTranscriptPath } = this.state;
-    const validationResult = OpenBotDialog.validateEndpoint(botUrl);
-    const errorMessage = OpenBotDialog.getErrorMessage(validationResult);
+    const urlValidationResult = OpenBotDialog.validateEndpoint(botUrl);
+    const pathValidationResult = OpenBotDialog.validatePath(botTranscriptPath);
+    const errorMessage = OpenBotDialog.getErrorMessage(urlValidationResult);
     const buttonShouldBeDisabled =
-      validationResult === ValidationResult.Invalid || validationResult === ValidationResult.Empty;
-    // const fieldShouldBeDisabled = !(botUrl.startsWith('http'));
+      (urlValidationResult === ValidationResult.Invalid || urlValidationResult === ValidationResult.Empty) &&
+      pathValidationResult === ValidationResult.Invalid;
+    const fieldShouldBeDisabled = !botUrl.startsWith('http');
     return (
       <Dialog cancel={this.props.onDialogCancel} className={openBotStyles.themeOverrides} title="Open a bot">
         <form onSubmit={this.onSubmit}>
@@ -124,8 +130,9 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
             onFocus={this.onFocus}
             placeholder="Path to save dialogs or transcripts"
             value={botTranscriptPath}
+            disabled={fieldShouldBeDisabled}
           >
-            <PrimaryButton className={openBotStyles.browseButton}>
+            <PrimaryButton className={openBotStyles.browseButton} disabled={fieldShouldBeDisabled}>
               Browse
               <input
                 accept=".bot"
@@ -174,7 +181,7 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
   private onInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { type, files, value, name } = event.target;
     let newValue = value;
-    if (name === 'botUrl') {
+    if (name === 'botUrl' || name === 'botTranscriptPath') {
       newValue = type === 'file' ? files.item(0).path : value;
     }
     this.setState({ [name]: newValue });

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialogContainer.ts
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialogContainer.ts
@@ -43,13 +43,14 @@ const mapDispatchToProps = (dispatch: (action: Action) => void): OpenBotDialogPr
   return {
     openBot: (componentState: OpenBotDialogState) => {
       DialogService.hideDialog();
-      const { appId = '', appPassword = '', botUrl = '' } = componentState;
+      const { appId = '', appPassword = '', botUrl = '', botTranscriptPath = '' } = componentState;
       if (botUrl.startsWith('http')) {
         dispatch(
           openBotViaUrlAction({
             appId,
             appPassword,
             endpoint: botUrl,
+            transcriptPath: botTranscriptPath,
           })
         );
       } else {

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialogContainer.ts
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialogContainer.ts
@@ -43,14 +43,13 @@ const mapDispatchToProps = (dispatch: (action: Action) => void): OpenBotDialogPr
   return {
     openBot: (componentState: OpenBotDialogState) => {
       DialogService.hideDialog();
-      const { appId = '', appPassword = '', botUrl = '', botTranscriptPath = '' } = componentState;
+      const { appId = '', appPassword = '', botUrl = '' } = componentState;
       if (botUrl.startsWith('http')) {
         dispatch(
           openBotViaUrlAction({
             appId,
             appPassword,
             endpoint: botUrl,
-            transcriptPath: botTranscriptPath,
           })
         );
       } else {

--- a/packages/app/client/src/ui/editor/emulator/emulator.tsx
+++ b/packages/app/client/src/ui/editor/emulator/emulator.tsx
@@ -176,14 +176,18 @@ export class EmulatorComponent extends React.Component<EmulatorProps, {}> {
 
     const userId = requireNewUserId ? uniqueIdv4() : props.document.userId;
     if (requireNewUserId) {
-      await CommandServiceImpl.remoteCall(SharedConstants.Commands.Emulator.SetCurrentUser, userId);
+      await CommandServiceImpl.remoteCall(
+        SharedConstants.Commands.Emulator.SetCurrentUser,
+        '9ec97590-5894-47df-9c26-de692ed12155'
+      );
     }
+    console.log(userId);
 
     const options = {
       conversationId,
       conversationMode: props.mode,
       endpointId: props.endpointId,
-      userId,
+      userId: '9ec97590-5894-47df-9c26-de692ed12155',
     };
 
     if (props.document.directLine) {

--- a/packages/app/client/src/ui/helpers/activeBotHelper.ts
+++ b/packages/app/client/src/ui/helpers/activeBotHelper.ts
@@ -181,9 +181,9 @@ export const ActiveBotHelper = new class {
     });
   }
 
-  async confirmAndOpenBotFromURL(): Promise<any> {
+  async confirmAndOpenBotFromURL(path?: string): Promise<any> {
     const bot: BotConfigWithPathImpl = new BotConfigWithPathImpl();
-    bot.path = 'C:\\Users\\Micaela\\Desktop';
+    bot.path = path;
     await CommandServiceImpl.remoteCall(SharedConstants.Commands.Bot.SetActive, bot);
   }
 

--- a/packages/app/client/src/ui/helpers/activeBotHelper.ts
+++ b/packages/app/client/src/ui/helpers/activeBotHelper.ts
@@ -32,7 +32,7 @@
 //
 
 import { getBotDisplayName, newNotification, SharedConstants } from '@bfemulator/app-shared';
-import { BotConfigWithPath, mergeEndpoints } from '@bfemulator/sdk-shared';
+import { BotConfigWithPath, mergeEndpoints, BotConfigWithPathImpl } from '@bfemulator/sdk-shared';
 import { IEndpointService, ServiceTypes } from 'botframework-config/lib/schema';
 
 import * as Constants from '../../constants';
@@ -179,6 +179,12 @@ export const ActiveBotHelper = new class {
       properties: ['openFile'],
       title: 'Open bot file',
     });
+  }
+
+  async confirmAndOpenBotFromURL(): Promise<any> {
+    const bot: BotConfigWithPathImpl = new BotConfigWithPathImpl();
+    bot.path = 'C:\\Users\\Micaela\\Desktop';
+    await CommandServiceImpl.remoteCall(SharedConstants.Commands.Bot.SetActive, bot);
   }
 
   async confirmAndOpenBotFromFile(filename?: string): Promise<any> {

--- a/packages/app/client/src/ui/helpers/activeBotHelper.ts
+++ b/packages/app/client/src/ui/helpers/activeBotHelper.ts
@@ -181,7 +181,7 @@ export const ActiveBotHelper = new class {
     });
   }
 
-  async confirmAndOpenBotFromURL(path?: string): Promise<any> {
+  async confirmAndOpenBotFromURL(path: string): Promise<any> {
     const bot: BotConfigWithPathImpl = new BotConfigWithPathImpl();
     bot.path = path;
     await CommandServiceImpl.remoteCall(SharedConstants.Commands.Bot.SetActive, bot);

--- a/packages/app/main/src/botHelpers.ts
+++ b/packages/app/main/src/botHelpers.ts
@@ -49,6 +49,12 @@ export function getBotInfoByPath(path: string): BotInfo {
   return store.getState().bot.botFiles.find(bot => bot && bot.path === path);
 }
 
+export function getInfoByUrl(bot: BotConfigWithPath): BotInfo {
+  return {
+    path: bot.path,
+  };
+}
+
 export function pathExistsInRecentBots(path: string): boolean {
   return store.getState().bot.botFiles.some(bot => bot && bot.path === path);
 }

--- a/packages/app/main/src/commands/botCommands.ts
+++ b/packages/app/main/src/commands/botCommands.ts
@@ -51,7 +51,6 @@ import {
   removeBotFromList,
   saveBot,
   toSavableBot,
-  getInfoByUrl,
 } from '../botHelpers';
 import { emulator } from '../emulator';
 import { mainWindow } from '../main';
@@ -158,7 +157,9 @@ export function registerCommands(commandRegistry: CommandRegistryImpl) {
       store.dispatch(BotActions.setActive(bot));
       store.dispatch(BotActions.setDirectory(botDirectory));
 
-      const botInfo = getInfoByUrl(bot) || getBotInfoByPath(bot.path);
+      const botInfo: BotInfo = {
+        path: bot.path,
+      };
 
       const {
         chatsPath = path.join(botDirectory, './dialogs'),

--- a/packages/app/main/src/commands/botCommands.ts
+++ b/packages/app/main/src/commands/botCommands.ts
@@ -51,6 +51,7 @@ import {
   removeBotFromList,
   saveBot,
   toSavableBot,
+  getInfoByUrl,
 } from '../botHelpers';
 import { emulator } from '../emulator';
 import { mainWindow } from '../main';
@@ -157,12 +158,11 @@ export function registerCommands(commandRegistry: CommandRegistryImpl) {
       store.dispatch(BotActions.setActive(bot));
       store.dispatch(BotActions.setDirectory(botDirectory));
 
-      const botInfo = getBotInfoByPath(bot.path) || {};
-      const dirName = path.dirname(bot.path);
+      const botInfo = getInfoByUrl(bot) || getBotInfoByPath(bot.path);
 
       const {
-        chatsPath = path.join(dirName, './dialogs'),
-        transcriptsPath = path.join(dirName, './transcripts'),
+        chatsPath = path.join(botDirectory, './dialogs'),
+        transcriptsPath = path.join(botDirectory, './transcripts'),
       } = botInfo;
       const botFilePath = path.parse(botInfo.path || '').dir;
       const relativeChatsPath = path.relative(botFilePath, chatsPath);

--- a/packages/app/main/src/commands/emulatorCommands.ts
+++ b/packages/app/main/src/commands/emulatorCommands.ts
@@ -41,7 +41,7 @@ import { sync as mkdirpSync } from 'mkdirp';
 
 import * as BotActions from '../botData/actions/botActions';
 import { getStore } from '../botData/store';
-import { getActiveBot, getBotInfoByPath, patchBotsJson, toSavableBot } from '../botHelpers';
+import { getActiveBot, getBotInfoByPath, patchBotsJson, toSavableBot, getInfoByUrl } from '../botHelpers';
 import { emulator } from '../emulator';
 import { mainWindow } from '../main';
 import { dispatch, getStore as getSettingsStore } from '../settingsData/store';
@@ -68,8 +68,8 @@ export function registerCommands(commandRegistry: CommandRegistryImpl) {
       if (!convo) {
         throw new Error(`${Commands.SaveTranscriptToFile}: Conversation ${conversationId} not found.`);
       }
-      let botInfo = getBotInfoByPath(activeBot.path);
       const dirName = path.dirname(activeBot.path);
+      let botInfo = getInfoByUrl(activeBot) || getBotInfoByPath(activeBot.path);
 
       const { transcriptsPath = path.join(dirName, './transcripts') } = botInfo;
 

--- a/packages/sdk/shared/src/types/activity/startConversationParams.ts
+++ b/packages/sdk/shared/src/types/activity/startConversationParams.ts
@@ -39,4 +39,5 @@ export interface StartConversationParams extends ConversationParameters {
   appId?: string;
   appPassword?: string;
   user?: User;
+  transcriptPath?: string;
 }


### PR DESCRIPTION
Fixes for Issue # 1387

The solution chosen was to modify `commandRegistry.registerCommand` method for the `Bot.SetActive` command. This will handle the bot’s activation when it’s created via URL. 
In order to apply this solution we had to modify the UI of the _Open Bot Dialog_ by adding a new _Input Field_ for the Path. This path is necessary to activate the Bot (using the `Bot.SetActive` command), which will enable the _Save Transcript_ Button.

Note that this approach **changes the user experience** but it's the best solution that we found without having to do a refactor of the whole functionality of the _Save Transcript File_.

### Changes made
- Add Input Field to OpenBotDialog UI for the path where the transcript file is going to be saved when using a _URL_
- Add UI Validations for:
           1. The new Input Field for the Path will be enabled only when using an _URL_
           2. The Connect Button will be enabled only when the _.bot file_ is correct or, when using an _URL_, 
               both the _URL_ and _Path_ are correct.
- Update the constant `botInfo` on `botCommand.ts` file to use the set path instead of retrieving the information from the botfile. This will set the Bot to active when using both _.bot file_ or _URL_ to initialize.

![imagen](https://user-images.githubusercontent.com/22912283/55754777-d414d100-5a23-11e9-83d9-63573df5468e.png)

### Testing
#### Manual testing
![BETranscript-Test](https://user-images.githubusercontent.com/22912283/55755536-9d3fba80-5a25-11e9-85d1-914d9a0650b6.gif)

#### Automated testing
Shortly we will be adding the proper tests to contemplate the new generated scenarios and increase the code coverage.

#### Note:
For the _Path Input Field_ we are using a _Text Field_ because the _Input File_ component is not supporting the `webkitdirectory` attribute. This should be an implemented before this PR is merged.