### PR TITLE
Allow the Emulator user to specify a User ID

### DIFF
--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -95,13 +95,14 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
   private usingCustomId() {
     return this.state.userGUID ? true : this.state.useCustomId;
   }
+  public GUIDValidator(guid: string) {
+    const charSec = n => `[a-z\\d]{${n}}`;
+    return RegExp([charSec(8), charSec(4), charSec(4), charSec(4), charSec(12)].join('-')).test(guid);
+  }
 
   public render(): JSX.Element {
     const { state } = this;
-    const charSec = n => `[a-z\\d]{${n}}`;
-    const validationResult = RegExp([charSec(8), charSec(4), charSec(4), charSec(4), charSec(12)].join('-')).test(
-      state.userGUID
-    );
+    const validationResult = this.GUIDValidator(state.userGUID);
     const errorMessage = validationResult ? '' : 'Please enter a valid user ID';
 
     return (

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -193,7 +193,7 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
               checked={this.usingCustomId()}
               onChange={this.onChangeCheckBox}
               id="use-custom-id"
-              label="Use your own ID to communicate with the bot"
+              label="Use your own user ID to communicate with the bot"
               name="useCustomId"
             />
             <Row align={RowAlignment.Top}>

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -165,6 +165,17 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
                 label="Locale"
               />
             </Row>
+            <Row align={RowAlignment.Center}>
+              <TextField
+                className={styles.appSettingsInput}
+                inputContainerClassName={styles.inputContainer}
+                readOnly={false}
+                value={state.userGUID}
+                name="userGUID"
+                onChange={this.onInputChange}
+                label="GUID"
+              />
+            </Row>
           </Column>
           <Column className={[styles.rightColumn, styles.spacing].join(' ')}>
             <SmallHeader>Auth</SmallHeader>

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -91,7 +91,9 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
   public componentDidMount(): void {
     this.props.getFrameworkSettings();
   }
-
+  private usingCustomId() {
+    return this.state.userGUID ? true : this.state.useCustomId;
+  }
   public render(): JSX.Element {
     const { state } = this;
 
@@ -186,7 +188,7 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
             />
             <Checkbox
               className={styles.checkboxOverrides}
-              checked={state.useCustomId}
+              checked={this.usingCustomId()}
               onChange={this.onChangeCheckBox}
               id="use-custom-id"
               label="Use your own ID to communicate with the bot"
@@ -200,8 +202,8 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
                 value={state.userGUID}
                 name="userGUID"
                 onChange={this.onInputChange}
-                disabled={!state.useCustomId}
-                required={state.useCustomId}
+                disabled={!this.usingCustomId()}
+                required={this.usingCustomId()}
                 label="User ID"
               />
             </Row>

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -98,6 +98,11 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
 
   public render(): JSX.Element {
     const { state } = this;
+    const charSec = n => `[a-z\\d]{${n}}`;
+    const validationResult = RegExp([charSec(8), charSec(4), charSec(4), charSec(4), charSec(12)].join('-')).test(
+      state.userGUID
+    );
+    const errorMessage = validationResult ? '' : 'Please enter a valid user ID';
 
     return (
       <GenericDocument className={styles.appSettingsEditor}>
@@ -207,6 +212,7 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
                 disabled={!this.usingCustomId()}
                 required={this.usingCustomId()}
                 label="User ID"
+                errorMessage={errorMessage}
               />
             </Row>
             <SmallHeader>Application Updates</SmallHeader>

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -192,17 +192,19 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
               label="Use your own ID to communicate with the bot"
               name="useCustomId"
             />
-            <TextField
-              className={styles.appSettingsInput}
-              inputContainerClassName={styles.inputContainer}
-              readOnly={false}
-              value={state.userGUID}
-              name="userGUID"
-              onChange={this.onInputChange}
-              label="GUID"
-              disabled={!state.useCustomId}
-              required={state.useCustomId}
-            />
+            <Row align={RowAlignment.Top}>
+              <TextField
+                className={styles.appSettingsInput}
+                inputContainerClassName={styles.inputContainer}
+                readOnly={false}
+                value={state.userGUID}
+                name="userGUID"
+                onChange={this.onInputChange}
+                disabled={!state.useCustomId}
+                required={state.useCustomId}
+                label="User ID"
+              />
+            </Row>
             <SmallHeader>Application Updates</SmallHeader>
             <Checkbox
               className={styles.checkboxOverrides}
@@ -246,7 +248,7 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
     this.setState(change);
     this.updateDirtyFlag(change);
 
-    if (name === 'useCustomId' && checked == false) this.state.userGUID = '';
+    if (name === 'useCustomId' && checked === false) this.setState({ ['userGUID']: '' });
   };
 
   private onClickBrowse = async (): Promise<void> => {

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -165,20 +165,9 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
                 label="Locale"
               />
             </Row>
-            <Row align={RowAlignment.Center}>
-              <TextField
-                className={styles.appSettingsInput}
-                inputContainerClassName={styles.inputContainer}
-                readOnly={false}
-                value={state.userGUID}
-                name="userGUID"
-                onChange={this.onInputChange}
-                label="GUID"
-              />
-            </Row>
           </Column>
           <Column className={[styles.rightColumn, styles.spacing].join(' ')}>
-            <SmallHeader>Auth</SmallHeader>
+            <SmallHeader>User settings</SmallHeader>
             <Checkbox
               className={styles.checkboxOverrides}
               checked={state.use10Tokens}
@@ -187,7 +176,6 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
               label="Use version 1.0 authentication tokens"
               name="use10Tokens"
             />
-            <SmallHeader>Sign-in</SmallHeader>
             <Checkbox
               className={styles.checkboxOverrides}
               checked={state.useCodeValidation}
@@ -195,6 +183,25 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
               id="use-validation-code"
               label="Use a sign-in verification code for OAuthCards"
               name="useCodeValidation"
+            />
+            <Checkbox
+              className={styles.checkboxOverrides}
+              checked={state.useCustomId}
+              onChange={this.onChangeCheckBox}
+              id="use-custom-id"
+              label="Use your own ID to communicate with the bot"
+              name="useCustomId"
+            />
+            <TextField
+              className={styles.appSettingsInput}
+              inputContainerClassName={styles.inputContainer}
+              readOnly={false}
+              value={state.userGUID}
+              name="userGUID"
+              onChange={this.onInputChange}
+              label="GUID"
+              disabled={!state.useCustomId}
+              required={state.useCustomId}
             />
             <SmallHeader>Application Updates</SmallHeader>
             <Checkbox
@@ -238,6 +245,8 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
     const change = { [name]: checked };
     this.setState(change);
     this.updateDirtyFlag(change);
+
+    if (name === 'useCustomId' && checked == false) this.state.userGUID = '';
   };
 
   private onClickBrowse = async (): Promise<void> => {

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -91,9 +91,11 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
   public componentDidMount(): void {
     this.props.getFrameworkSettings();
   }
+
   private usingCustomId() {
     return this.state.userGUID ? true : this.state.useCustomId;
   }
+
   public render(): JSX.Element {
     const { state } = this;
 

--- a/packages/app/client/src/ui/editor/emulator/emulator.spec.tsx
+++ b/packages/app/client/src/ui/editor/emulator/emulator.spec.tsx
@@ -63,6 +63,10 @@ jest.mock('../../../platform/commands/commandServiceImpl', () => ({
       if (commandName === mockSharedConstants.Commands.Emulator.FeedTranscriptFromDisk) {
         return Promise.resolve({ meta: 'some file info' });
       }
+      if (commandName === mockSharedConstants.Commands.Settings.LoadAppSettings) {
+        return Promise.resolve({ meta: 'some file info' });
+      }
+
       return Promise.resolve();
     },
   },
@@ -293,9 +297,9 @@ describe('<Emulator/>', () => {
     instance = wrapper.instance();
     instance.onExportClick();
 
-    expect(mockRemoteCallsMade).toHaveLength(2);
-    expect(mockRemoteCallsMade[1].commandName).toBe(SharedConstants.Commands.Emulator.SaveTranscriptToFile);
-    expect(mockRemoteCallsMade[1].args).toEqual(['convo1']);
+    expect(mockRemoteCallsMade).toHaveLength(4);
+    expect(mockRemoteCallsMade[3].commandName).toBe(SharedConstants.Commands.Emulator.SaveTranscriptToFile);
+    expect(mockRemoteCallsMade[3].args).toEqual(['convo1']);
   });
 
   it('should start a new conversation', async () => {
@@ -310,7 +314,7 @@ describe('<Emulator/>', () => {
     await instance.startNewConversation(undefined, false, false);
 
     expect(mockUnsubscribe).toHaveBeenCalled();
-    expect(mockRemoteCallsMade).toHaveLength(1);
+    expect(mockRemoteCallsMade).toHaveLength(5);
     expect(mockInitConversation).toHaveBeenCalledWith(
       instance.props,
       options,
@@ -350,9 +354,9 @@ describe('<Emulator/>', () => {
     };
     await instance.startNewConversation(undefined, false, true);
 
-    expect(mockRemoteCallsMade).toHaveLength(2);
-    expect(mockRemoteCallsMade[1].commandName).toBe(SharedConstants.Commands.Emulator.SetCurrentUser);
-    expect(mockRemoteCallsMade[1].args).toEqual([options.userId]);
+    expect(mockRemoteCallsMade).toHaveLength(5);
+    expect(mockRemoteCallsMade[4].commandName).toBe(SharedConstants.Commands.Emulator.SetCurrentUser);
+    expect(mockRemoteCallsMade[4].args).toEqual([options.userId]);
     expect(mockInitConversation).toHaveBeenCalledWith(
       instance.props,
       options,
@@ -368,9 +372,9 @@ describe('<Emulator/>', () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(clearLog('doc1'));
     expect(mockDispatch).toHaveBeenCalledWith(setInspectorObjects('doc1', []));
-    expect(mockRemoteCallsMade).toHaveLength(2);
-    expect(mockRemoteCallsMade[1].commandName).toBe(SharedConstants.Commands.Telemetry.TrackEvent);
-    expect(mockRemoteCallsMade[1].args).toEqual(['conversation_restart', { userId: 'new' }]);
+    expect(mockRemoteCallsMade).toHaveLength(4);
+    expect(mockRemoteCallsMade[3].commandName).toBe(SharedConstants.Commands.Telemetry.TrackEvent);
+    expect(mockRemoteCallsMade[3].args).toEqual(['conversation_restart', { userId: 'new' }]);
     expect(mockStartNewConversation).toHaveBeenCalledWith(undefined, true, true);
   });
 
@@ -381,9 +385,9 @@ describe('<Emulator/>', () => {
 
     expect(mockDispatch).toHaveBeenCalledWith(clearLog('doc1'));
     expect(mockDispatch).toHaveBeenCalledWith(setInspectorObjects('doc1', []));
-    expect(mockRemoteCallsMade).toHaveLength(2);
-    expect(mockRemoteCallsMade[1].commandName).toBe(SharedConstants.Commands.Telemetry.TrackEvent);
-    expect(mockRemoteCallsMade[1].args).toEqual(['conversation_restart', { userId: 'same' }]);
+    expect(mockRemoteCallsMade).toHaveLength(4);
+    expect(mockRemoteCallsMade[3].commandName).toBe(SharedConstants.Commands.Telemetry.TrackEvent);
+    expect(mockRemoteCallsMade[3].args).toEqual(['conversation_restart', { userId: 'same' }]);
     expect(mockStartNewConversation).toHaveBeenCalledWith(undefined, true, false);
   });
 
@@ -425,11 +429,11 @@ describe('<Emulator/>', () => {
 
     await instance.startNewConversation(mockProps);
 
-    expect(mockRemoteCallsMade).toHaveLength(3);
-    expect(mockRemoteCallsMade[1].commandName).toBe(SharedConstants.Commands.Emulator.NewTranscript);
-    expect(mockRemoteCallsMade[1].args).toEqual(['someUniqueId|transcript']);
-    expect(mockRemoteCallsMade[2].commandName).toBe(SharedConstants.Commands.Emulator.FeedTranscriptFromMemory);
-    expect(mockRemoteCallsMade[2].args).toEqual(['someConvoId', 'someBotId', 'someUserId', []]);
+    expect(mockRemoteCallsMade).toHaveLength(7);
+    expect(mockRemoteCallsMade[5].commandName).toBe(SharedConstants.Commands.Emulator.NewTranscript);
+    expect(mockRemoteCallsMade[5].args).toEqual(['someUniqueId|transcript']);
+    expect(mockRemoteCallsMade[6].commandName).toBe(SharedConstants.Commands.Emulator.FeedTranscriptFromMemory);
+    expect(mockRemoteCallsMade[6].args).toEqual(['someConvoId', 'someBotId', 'someUserId', []]);
   });
 
   it('should start a new conversation from transcript on disk', async () => {
@@ -449,11 +453,11 @@ describe('<Emulator/>', () => {
 
     await instance.startNewConversation(mockProps);
 
-    expect(mockRemoteCallsMade).toHaveLength(3);
-    expect(mockRemoteCallsMade[1].commandName).toBe(SharedConstants.Commands.Emulator.NewTranscript);
-    expect(mockRemoteCallsMade[1].args).toEqual(['someUniqueId|transcript']);
-    expect(mockRemoteCallsMade[2].commandName).toBe(SharedConstants.Commands.Emulator.FeedTranscriptFromDisk);
-    expect(mockRemoteCallsMade[2].args).toEqual(['someConvoId', 'someBotId', 'someUserId', 'someDocId']);
+    expect(mockRemoteCallsMade).toHaveLength(7);
+    expect(mockRemoteCallsMade[5].commandName).toBe(SharedConstants.Commands.Emulator.NewTranscript);
+    expect(mockRemoteCallsMade[5].args).toEqual(['someUniqueId|transcript']);
+    expect(mockRemoteCallsMade[6].commandName).toBe(SharedConstants.Commands.Emulator.FeedTranscriptFromDisk);
+    expect(mockRemoteCallsMade[6].args).toEqual(['someConvoId', 'someBotId', 'someUserId', 'someDocId']);
     expect(mockDispatch).toHaveBeenCalledWith(updateDocument('someDocId', { meta: 'some file info' }));
   });
 });

--- a/packages/app/client/src/ui/editor/emulator/emulator.tsx
+++ b/packages/app/client/src/ui/editor/emulator/emulator.tsx
@@ -149,10 +149,10 @@ export class EmulatorComponent extends React.Component<EmulatorProps, {}> {
       props.document.subscription.unsubscribe();
     }
     if (!requireNewUserId) {
-      requireNewUserId == false;
+      requireNewUserId = false;
     }
     if (!requireNewConvoId) {
-      requireNewUserId == false;
+      requireNewConvoId = false;
     }
     const selectedActivity$ = new BehaviorSubject<Activity | null>({});
     const subscription = selectedActivity$.subscribe(activity => {
@@ -166,13 +166,10 @@ export class EmulatorComponent extends React.Component<EmulatorProps, {}> {
     const conversationId = requireNewConvoId
       ? `${uniqueId()}|${props.mode}`
       : props.document.conversationId || `${uniqueId()}|${props.mode}`;
-
     const framework: FrameworkSettings = await CommandServiceImpl.remoteCall(
       SharedConstants.Commands.Settings.LoadAppSettings
     );
-
     const stableId = framework.userGUID || props.document.userId;
-
     const userId = requireNewUserId ? uniqueIdv4() : stableId;
 
     await CommandServiceImpl.remoteCall(SharedConstants.Commands.Emulator.SetCurrentUser, userId);

--- a/packages/app/client/src/ui/editor/emulator/emulator.tsx
+++ b/packages/app/client/src/ui/editor/emulator/emulator.tsx
@@ -39,7 +39,7 @@ import { IEndpointService } from 'botframework-config/lib/schema';
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { BehaviorSubject } from 'rxjs';
-import { newNotification, Notification, SharedConstants } from '@bfemulator/app-shared';
+import { newNotification, Notification, SharedConstants, FrameworkSettings } from '@bfemulator/app-shared';
 
 import * as ChatActions from '../../../data/action/chatActions';
 import { updateDocument } from '../../../data/action/editorActions';
@@ -113,7 +113,7 @@ export class EmulatorComponent extends React.Component<EmulatorProps, {}> {
   componentWillMount() {
     window.addEventListener('keydown', this.keyboardEventListener);
     if (this.shouldStartNewConversation()) {
-      this.startNewConversation();
+      // this.startNewConversation();
     }
   }
 
@@ -174,10 +174,15 @@ export class EmulatorComponent extends React.Component<EmulatorProps, {}> {
       ? `${uniqueId()}|${props.mode}`
       : props.document.conversationId || `${uniqueId()}|${props.mode}`;
 
-    const userId = requireNewUserId ? uniqueIdv4() : props.document.userId;
-    if (requireNewUserId) {
-      await CommandServiceImpl.remoteCall(SharedConstants.Commands.Emulator.SetCurrentUser, userId);
-    }
+    const framework: FrameworkSettings = await CommandServiceImpl.remoteCall(
+      SharedConstants.Commands.Settings.LoadAppSettings
+    );
+
+    const stableId = framework.userGUID; // framework.userGUID.toString() || props.document.userId;
+
+    const userId = requireNewUserId ? uniqueIdv4() : stableId || props.document.userId;
+
+    await CommandServiceImpl.remoteCall(SharedConstants.Commands.Emulator.SetCurrentUser, userId);
 
     const options = {
       conversationId,

--- a/packages/app/client/src/ui/editor/emulator/emulator.tsx
+++ b/packages/app/client/src/ui/editor/emulator/emulator.tsx
@@ -369,6 +369,7 @@ export class EmulatorComponent extends React.Component<EmulatorProps, {}> {
     const { NewUserId, SameUserId } = RestartConversationOptions;
     this.props.clearLog(this.props.document.documentId);
     this.props.setInspectorObjects(this.props.document.documentId, []);
+
     switch (option) {
       case NewUserId: {
         this.props.trackEvent('conversation_restart', {

--- a/packages/app/client/src/ui/editor/emulator/emulator.tsx
+++ b/packages/app/client/src/ui/editor/emulator/emulator.tsx
@@ -126,7 +126,6 @@ export class EmulatorComponent extends React.Component<EmulatorProps, {}> {
 
   componentWillReceiveProps(nextProps: EmulatorProps) {
     const { props, keyboardEventListener } = this;
-
     const switchedDocuments = props.activeDocumentId !== nextProps.activeDocumentId;
     const switchedToThisDocument = nextProps.activeDocumentId === props.documentId;
 

--- a/packages/app/main/src/commands/settingsCommands.spec.ts
+++ b/packages/app/main/src/commands/settingsCommands.spec.ts
@@ -39,7 +39,7 @@ import { setFramework } from '../settingsData/actions/frameworkActions';
 
 import { registerCommands } from './settingsCommands';
 
-const mockSettings = { framework: { ngrokPath: 'path/to/ngrok.exe' } };
+const mockSettings = { framework: { ngrokPath: 'path/to/ngrok.exe', userGUID: 'aRandomUser' } };
 let mockDispatch;
 jest.mock('../settingsData/store', () => ({
   get dispatch() {
@@ -78,6 +78,13 @@ describe('The settings commands', () => {
     const { handler } = mockRegistry.getCommand(SharedConstants.Commands.Settings.LoadAppSettings);
     const appSettings = await handler();
 
-    expect(appSettings).toBe(mockSettings.framework);
+    expect(appSettings.ngrokPath).toBe(mockSettings.framework.ngrokPath);
+  });
+
+  it('should load the app settings from the store', async () => {
+    const { handler } = mockRegistry.getCommand(SharedConstants.Commands.Settings.LoadAppSettings);
+    const appSettings = await handler();
+
+    expect(appSettings.userGUID).toBe(mockSettings.framework.userGUID);
   });
 });

--- a/packages/app/shared/src/types/serverSettingsTypes.ts
+++ b/packages/app/shared/src/types/serverSettingsTypes.ts
@@ -60,6 +60,8 @@ export interface FrameworkSettings {
   collectUsageData?: boolean;
   // Digest of k/v pairs for integrity
   hash?: string;
+  // GUID set by the user
+  userGUID?: string;
 }
 
 export interface WindowStateSettings {
@@ -132,6 +134,7 @@ export const frameworkDefault: FrameworkSettings = {
   usePrereleases: false,
   autoUpdate: true,
   collectUsageData: false,
+  userGUID: '',
 };
 
 export const windowStateDefault: WindowStateSettings = {

--- a/packages/app/shared/src/types/serverSettingsTypes.ts
+++ b/packages/app/shared/src/types/serverSettingsTypes.ts
@@ -62,6 +62,8 @@ export interface FrameworkSettings {
   hash?: string;
   // GUID set by the user
   userGUID?: string;
+  // use custom user id
+  useCustomId?: boolean;
 }
 
 export interface WindowStateSettings {


### PR DESCRIPTION
Fixes # 1344
### Description
This PR allows the Emulator users to specify a User ID which will be used within conversations.

### Changes made
#### Functionality changes
To implement this feature we made the following changes:
- Add an input to the Emulator Settings so that the user can configure a GUID
- Change the `startNewConversation` method to choose between a randomly generated UserId, the UserId set in the props or the UserId set by the user.'
- When the _Use custom id_ checkbox is set to `false`, the input is disabled and cleaned. When `true`, it is a required field and it gets enabled.
- The _User ID_ field has a validation so that the user is not able to enter anything other than a GUID.
- Restarting a conversation with the same userId will choose between the one set by the user or the one set by default (if the first one is empty).
- Restarting a conversation with a new userId will generate a random ID the same way it was doing it until now.

#### UI Changes

**Before**
![imagen](https://user-images.githubusercontent.com/22912283/55966380-a790cd00-5c4e-11e9-86db-d1d0383bf078.png)

**After**
![imagen](https://user-images.githubusercontent.com/22912283/55969430-2805fc80-5c54-11e9-837b-09bed60f31de.png)

### Testing
**Manual testing**
![BFE-Userid](https://user-images.githubusercontent.com/22912283/55964442-208e2580-5c4b-11e9-9def-18eca3160b50.gif)

**Automated testing**
We will be adding tests on another PR