### PR TITLE
[ISSUE#1534] Fix Removing an overridden User ID doesn't remove the overridden User ID in conversations

### DIFF
--- a/packages/app/client/src/conversationDefault.ts
+++ b/packages/app/client/src/conversationDefault.ts
@@ -1,0 +1,36 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license.
+//
+// Microsoft Bot Framework: http://botframework.com
+//
+// Bot Framework Emulator Github:
+// https://github.com/Microsoft/BotFramwork-Emulator
+//
+// Copyright (c) Microsoft Corporation
+// All rights reserved.
+//
+// MIT License:
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+export const conversationDefaults: any = {
+  userId: 'genericUserId',
+  documentId: 'genericConversationId',
+};

--- a/packages/app/client/src/data/sagas/servicesExplorerSagas.spec.ts
+++ b/packages/app/client/src/data/sagas/servicesExplorerSagas.spec.ts
@@ -34,6 +34,7 @@ import { ServiceCodes, SharedConstants } from '@bfemulator/app-shared';
 import { ServiceTypes } from 'botframework-config/lib/schema';
 import { applyMiddleware, combineReducers, createStore } from 'redux';
 import sagaMiddlewareFactory from 'redux-saga';
+import { call } from 'redux-saga/effects';
 
 import { CommandServiceImpl } from '../../platform/commands/commandServiceImpl';
 import {
@@ -61,8 +62,6 @@ import { azureAuth } from '../reducer/azureAuthReducer';
 import { bot } from '../reducer/bot';
 
 import { launchExternalLink as launchExternalLinkSaga, servicesExplorerSagas } from './servicesExplorerSagas';
-
-import { call } from 'redux-saga/effects';
 
 const sagaMiddleWare = sagaMiddlewareFactory();
 const mockStore = createStore(combineReducers({ azureAuth, bot }), {}, applyMiddleware(sagaMiddleWare));

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
@@ -41,7 +41,7 @@ import * as openBotStyles from './openBotDialog.scss';
 export interface OpenBotDialogProps {
   onDialogCancel?: () => void;
   openBot?: (state: OpenBotDialogState) => void;
-  savedBotUrls?: Array<{ url: string; lastAccessed: string }>;
+  savedBotUrls?: { url: string; lastAccessed: string }[];
   sendNotification?: (error: Error) => void;
   switchToBot?: (path: string) => void;
   debugMode?: DebugMode;

--- a/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
+++ b/packages/app/client/src/ui/editor/appSettingsEditor/appSettingsEditor.tsx
@@ -255,17 +255,17 @@ export class AppSettingsEditor extends React.Component<AppSettingsEditorProps, A
   }
 
   private disableSaveButton(): boolean {
-    return this.state.useCustomId ? !this.state.userGUID : !this.state.dirty;
+    return this.state.useCustomId ? !this.state.userGUID && !this.state.dirty : !this.state.dirty;
   }
 
   private onChangeCheckBox = (event: ChangeEvent<HTMLInputElement>) => {
     const { name, checked } = event.target;
     const change = { [name]: checked };
     this.setState(change);
-    this.updateDirtyFlag(change);
     if (name === 'useCustomId' && checked === false) {
-      this.setState({ userGUID: null });
+      this.setState({ userGUID: '' });
     }
+    this.updateDirtyFlag(change);
   };
 
   private onClickBrowse = async (): Promise<void> => {

--- a/packages/app/client/src/ui/editor/emulator/emulator.tsx
+++ b/packages/app/client/src/ui/editor/emulator/emulator.tsx
@@ -49,6 +49,7 @@ import {
 import { Document } from '../../../data/reducer/editor';
 import { CommandServiceImpl } from '../../../platform/commands/commandServiceImpl';
 import { debounce } from '../../../utils';
+import { conversationDefaults } from '../../../conversationDefault';
 
 import ChatPanel from './chatPanel/chatPanel';
 import LogPanel from './logPanel/logPanel';
@@ -56,7 +57,6 @@ import PlaybackBar from './playbackBar/playbackBar';
 import * as styles from './emulator.scss';
 import { InspectorContainer } from './parts';
 import { ToolBar } from './toolbar/toolbar';
-import { conversationDefaults } from '../../../conversationDefault';
 
 const { encode } = base64Url;
 

--- a/packages/app/client/src/ui/editor/emulator/emulator.tsx
+++ b/packages/app/client/src/ui/editor/emulator/emulator.tsx
@@ -56,6 +56,7 @@ import PlaybackBar from './playbackBar/playbackBar';
 import * as styles from './emulator.scss';
 import { InspectorContainer } from './parts';
 import { ToolBar } from './toolbar/toolbar';
+import { conversationDefaults } from '../../../conversationDefault';
 
 const { encode } = base64Url;
 
@@ -162,7 +163,7 @@ export class Emulator extends React.Component<EmulatorProps, {}> {
     const framework: FrameworkSettings = await CommandServiceImpl.remoteCall(
       SharedConstants.Commands.Settings.LoadAppSettings
     );
-    const stableId = framework.userGUID || props.document.userId;
+    const stableId = framework.userGUID || conversationDefaults.userId;
     const userId = requireNewUserId ? uniqueIdv4() : stableId;
 
     await CommandServiceImpl.remoteCall(SharedConstants.Commands.Emulator.SetCurrentUser, userId);

--- a/packages/app/main/src/settingsData/reducers/savedBotUrlsReducer.ts
+++ b/packages/app/main/src/settingsData/reducers/savedBotUrlsReducer.ts
@@ -33,15 +33,15 @@
 
 import { ADD_SAVED_BOT_URL, SavedBotUrlsAction, SavedBotUrlsActionPayload } from '../actions/savedBotUrlsActions';
 
-type BotUrl = {
+interface BotUrl {
   url: string;
   lastAccessed: string;
-};
+}
 
 export function savedBotUrlsReducer(
-  state: Array<BotUrl> = [],
+  state: BotUrl[] = [],
   action: SavedBotUrlsAction<SavedBotUrlsActionPayload>
-): Array<BotUrl> {
+): BotUrl[] {
   switch (action.type) {
     case ADD_SAVED_BOT_URL: {
       const foundAtIndex = state.findIndex(element => element.url === action.payload);

--- a/packages/app/shared/src/types/clientAwareSettings.ts
+++ b/packages/app/shared/src/types/clientAwareSettings.ts
@@ -39,5 +39,5 @@ export interface ClientAwareSettings {
   serverUrl: string;
   debugMode: DebugMode;
   users: UserSettings;
-  savedBotUrls: Array<{ url: string; lastAccessed: string }>;
+  savedBotUrls: { url: string; lastAccessed: string }[];
 }

--- a/packages/app/shared/src/types/serverSettingsTypes.ts
+++ b/packages/app/shared/src/types/serverSettingsTypes.ts
@@ -98,7 +98,7 @@ export interface AzureSettings {
 export interface PersistentSettings {
   framework?: FrameworkSettings;
   bots?: Bot[];
-  savedBotUrls?: Array<{ url: string; lastAccessed: string }>;
+  savedBotUrls?: { url: string; lastAccessed: string }[];
   windowState?: WindowStateSettings;
   users?: UserSettings;
 }
@@ -110,7 +110,7 @@ export interface Settings extends PersistentSettings {
 export class SettingsImpl implements Settings {
   public framework: FrameworkSettings;
   public bots: Bot[];
-  public savedBotUrls: Array<{ url: string; lastAccessed: string }>;
+  public savedBotUrls: { url: string; lastAccessed: string }[];
   public windowState: WindowStateSettings;
   public users: UserSettings;
   public azure: AzureSettings;


### PR DESCRIPTION
Fixes # 1534

### Description
This PR fixes the issue when removing an overridden User ID doesn't remove the overridden User ID in conversations

### Changes made
In order to handle this as clean as possible, we added a basic configuration file for all the conversations in which there's an stable `userId`, that'll be used when there's not `userId ` set from the Settings Page. 
By doing this, there's an inmutable set of data and mantains consistency through sessions.

#### Functionality changes
To implement this feature we made the following changes:

- Add new file `conversationDefaults` that has the `userId` and `documentId` stable values.
- Update `appSettingsEditor.tsx` file to set the userGUID as empty instead of null when the UserID from the Settings' Page is disabled.
- Update `emulator.tsx` file to import `conversationDefaults` values and use it instead of props.document.userID that is not being overriden on `stableId` variable declaration.