### PR TITLE
Add background in dialog explorer

### DIFF
--- a/packages/app/client/src/ui/shell/main.scss
+++ b/packages/app/client/src/ui/shell/main.scss
@@ -21,7 +21,19 @@
 
   & .mdi-wrapper {
     height: 100%;
+    width: 100%;  
+  }
+
+  & .mdi-wrapper::before {
+    content: "";
+    background-image: url('../media/ic_bot_framework.svg');
     width: 100%;
+    height: calc(100% - 70px); /* centered below toolbar */
+    background-size: 50% 50%;
+    background-position: 50% 50%;
+    background-repeat: no-repeat;
+    position: absolute;
+    opacity: .2;
   }
 
   & .secondary-mdi {

--- a/packages/app/client/src/ui/styles/themes/dark.css
+++ b/packages/app/client/src/ui/styles/themes/dark.css
@@ -132,7 +132,7 @@ html {
   --s-button-bg-disabled: var(--neutral-2);
 
   /* Dialogs & Modals */
-  --dialog-bg: var(--neutral-2);
+  --dialog-bg: var(--neutral-13);
   --dialog-color: var(--neutral-14);
   --dialog-error-color: var(--error-text);
 


### PR DESCRIPTION
Fixes `#1508`

# Specific changes
- Add background image in the dialog explorer
- Fix dialog-bg color in dark theme

# Testing
![image](https://user-images.githubusercontent.com/37461749/59299629-8145d880-8c63-11e9-8cb4-866243898349.png)