### PR TITLE
[ISSUE#1493] Azure Storage Accounts show container name only - should show storage + container name

### DIFF
--- a/packages/app/client/src/ui/shell/explorer/servicesExplorer/servicesExplorer.tsx
+++ b/packages/app/client/src/ui/shell/explorer/servicesExplorer/servicesExplorer.tsx
@@ -31,7 +31,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-import { IConnectedService, ServiceTypes } from 'botframework-config/lib/schema';
+import { IConnectedService, ServiceTypes, IBlobStorageService } from 'botframework-config/lib/schema';
 import * as React from 'react';
 import { MouseEventHandler, SyntheticEvent } from 'react';
 
@@ -129,11 +129,17 @@ export class ServicesExplorer extends ServicePane<ServicesExplorerProps> {
 
   protected get links() {
     const { services = [], toAnimate = {} } = this.state;
+
     return services.map((service, index) => {
-      let label = service.name;
+      let label =
+        service.type === ServiceTypes.BlobStorage ? (service as IBlobStorageService).serviceName : service.name;
+      const containerName =
+        service.type === ServiceTypes.BlobStorage ? '- ' + (service as IBlobStorageService).container + ' ' : '';
+
       if ('version' in service) {
         label += `, v${(service as any).version}`;
       }
+
       return (
         <li
           key={index}
@@ -145,7 +151,11 @@ export class ServicesExplorer extends ServicePane<ServicesExplorerProps> {
           title={service.name}
         >
           {iconMap[service.type]}
-          {label} <span>- {serviceTypeLabels[service.type]}</span>
+          {label}{' '}
+          <span>
+            {' '}
+            {containerName}- {serviceTypeLabels[service.type]}
+          </span>
         </li>
       );
     });


### PR DESCRIPTION
Fixes #  1493

# Description
Added container name variable and updated services' List Label to display Storage + Container name, only if it's a Blob Storage.

# Specific changes
- Add `containerName` variable to obtain the Service Container Name (If it's BlobStorage)
- Update label used on `get links` when the Service Type is  BlobStorage

# Testing
![imagen](https://user-images.githubusercontent.com/27219455/59943498-cb377700-9438-11e9-94ed-725d9af0e656.png)


