### PR TITLE
[ISSUE#1622] Update getEndpoint function

### DIFF
--- a/packages/emulator/core/src/conversations/middleware/getBotEndpoint.ts
+++ b/packages/emulator/core/src/conversations/middleware/getBotEndpoint.ts
@@ -65,14 +65,10 @@ export default function getBotEndpoint(botEmulator: BotEmulator) {
           new BotEndpoint(params.bot.id, params.bot.id, botUrl, msaAppId, msaPassword, false, channelService)
         );
       } else {
-        // update the endpoint in memory with the new
-        // appId and password if they exist in the params
-        if (msaAppId) {
-          endpoint.msaAppId = msaAppId;
-        }
-        if (msaPassword) {
-          endpoint.msaPassword = msaPassword;
-        }
+        // update the endpoint in memory with the
+        // appId and password passed in the params
+        endpoint.msaAppId = msaAppId;
+        endpoint.msaPassword = msaPassword;
       }
       request.botEndpoint = endpoint;
     } else {


### PR DESCRIPTION
fix `#1622`

# Description
The existing validations ([here](https://github.com/microsoft/BotFramework-Emulator/blob/88bfc5531e8a2c45db4a6f790db78abbb1f5b68b/packages/emulator/core/src/conversations/middleware/getBotEndpoint.ts#L70-L75)) were not taking into account the case in which a user wants to connect a bot to the emulator using the same endpoint without credentials. We remove the validations to able to rewrite the existing credentials with no contents in this case. 

# Specific changes
- Remove validations to be able to connect a bot without credentials

# Testing
We following the steps to reproduce the issue and the bots were connected successfully.
![image](https://user-images.githubusercontent.com/37461749/60297545-ceca7280-98fe-11e9-8351-fc9df6fd096d.png)

