### PR TITLE
Added a div with the tabIndex attribute to announce the dialog content

### DIFF
--- a/packages/app/client/src/ui/dialogs/connectServicePromptDialog/connectServicePromptDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/connectServicePromptDialog/connectServicePromptDialog.tsx
@@ -58,7 +58,7 @@ export class ConnectServicePromptDialog extends Component<ConnectServicePromptDi
   public render() {
     return (
       <Dialog className={styles.dialogMedium} cancel={this.props.cancel} title={titleMap[this.props.serviceType]}>
-        {this.dialogContent}
+        <div tabIndex={0}>{this.dialogContent}</div>
         <DialogFooter>
           <DefaultButton text="Cancel" onClick={this.props.cancel} />
           <PrimaryButton text="Sign in with Azure" onClick={this.props.confirm} />


### PR DESCRIPTION
Fixes MS64726

### Description

As reported by the issue, when opening the LUIS dialog, the screen reader was not providing the proper information about the dialog and its content.

### Changes made

- Added a DIV element to enable the screen reader to read the dialog title and its content.

### Testing

Test cases executed successfully.
![imagen](https://user-images.githubusercontent.com/62261539/145598209-eb785a7d-98f0-48fc-8d0b-466deb2b0d77.png)
