### PR TITLE
fix:[#2398] Support Bots that use Single Tenant AAD Applications

### DIFF
--- a/packages/app/client/src/commands/emulatorCommands.ts
+++ b/packages/app/client/src/commands/emulatorCommands.ts
@@ -68,6 +68,7 @@ export class EmulatorCommands {
       openBotViaUrlAction({
         appId: endpoint.appId,
         appPassword: endpoint.appPassword,
+        tenantId: endpoint.tenantId,
         channelService: endpoint.channelService as ChannelService,
         endpoint: endpoint.endpoint,
         isFromBotFile: true,

--- a/packages/app/client/src/state/sagas/botSagas.ts
+++ b/packages/app/client/src/state/sagas/botSagas.ts
@@ -110,7 +110,7 @@ export class BotSagas {
       mode: action.payload.mode,
       msaAppId: action.payload.appId,
       msaPassword: action.payload.appPassword,
-      tenantId: action.payload.tenantId,
+      msaTenantId: action.payload.tenantId,
     };
     let res: Response = yield call([ConversationService, ConversationService.startConversation], serverUrl, payload);
     if (!res.ok) {
@@ -136,7 +136,7 @@ export class BotSagas {
       speechKey: action.payload.speechKey,
       speechRegion: action.payload.speechRegion,
       user,
-      tenantId: action.payload.tenantId,
+      msaTenantId: action.payload.tenantId,
     });
 
     // add a document to the store so the livechat tab is rendered

--- a/packages/app/client/src/state/sagas/botSagas.ts
+++ b/packages/app/client/src/state/sagas/botSagas.ts
@@ -110,6 +110,7 @@ export class BotSagas {
       mode: action.payload.mode,
       msaAppId: action.payload.appId,
       msaPassword: action.payload.appPassword,
+      tenantId: action.payload.tenantId,
     };
     let res: Response = yield call([ConversationService, ConversationService.startConversation], serverUrl, payload);
     if (!res.ok) {
@@ -135,6 +136,7 @@ export class BotSagas {
       speechKey: action.payload.speechKey,
       speechRegion: action.payload.speechRegion,
       user,
+      tenantId: action.payload.tenantId,
     });
 
     // add a document to the store so the livechat tab is rendered

--- a/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/botCreationDialog/botCreationDialog.tsx
@@ -98,6 +98,7 @@ export class BotCreationDialog extends React.Component<BotCreationDialogProps, B
         appId: '',
         appPassword: '',
         endpoint: '',
+        tenantId: '',
       }),
       isAzureGov: false,
       secret: '',
@@ -121,7 +122,7 @@ export class BotCreationDialog extends React.Component<BotCreationDialogProps, B
       <Dialog className={dialogStyles.main} title="New bot configuration" cancel={this.onCancel}>
         <div className={styles.botCreateForm}>
           <TextField
-            value={this.state.bot.name}
+            value={bot.name}
             data-prop="name"
             onChange={this.onInputChange}
             label={'Bot name'}
@@ -134,7 +135,7 @@ export class BotCreationDialog extends React.Component<BotCreationDialogProps, B
             placeholder={endpointPlaceholder}
             label={'Endpoint URL'}
             required={true}
-            value={this.state.endpoint.endpoint}
+            value={endpoint.endpoint}
             name={'create-bot-url'}
           />
           {endpointWarning && <span className={styles.endpointWarning}>{endpointWarning}</span>}
@@ -158,6 +159,13 @@ export class BotCreationDialog extends React.Component<BotCreationDialogProps, B
               value={endpoint.appPassword}
             />
           </Row>
+          <TextField
+            name="tenantId"
+            label="Tenant ID"
+            onChange={this.onInputChange}
+            placeholder="Optional"
+            value={endpoint.tenantId}
+          />
           <Row align={RowAlignment.Bottom}>
             <Checkbox label="Azure for US Government" checked={isAzureGov} onChange={this.onChannelServiceChange} />
             <LinkButton
@@ -350,6 +358,7 @@ export class BotCreationDialog extends React.Component<BotCreationDialogProps, B
       id: this.state.endpoint.id.trim(),
       appId: this.state.endpoint.appId.trim(),
       appPassword: this.state.endpoint.appPassword.trim(),
+      tenantId: this.state.endpoint.tenantId.trim(),
       endpoint: this.state.endpoint.endpoint.trim(),
     };
     (endpoint as any).channelService = (this.state.endpoint as any).channelService;

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialog.tsx
@@ -111,10 +111,19 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
 
   constructor(props: OpenBotDialogProps) {
     super(props);
-    const { appId = '', appPassword = '', botUrl = '', isAzureGov = false, isDebug = false, mode = 'livechat' } = props;
+    const {
+      appId = '',
+      appPassword = '',
+      botUrl = '',
+      isAzureGov = false,
+      isDebug = false,
+      mode = 'livechat',
+      tenantId,
+    } = props;
     this.state = {
       appId,
       appPassword,
+      tenantId,
       botUrl,
       isAzureGov,
       isDebug,
@@ -132,6 +141,7 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
       botUrl,
       appId,
       appPassword,
+      tenantId,
       mode,
       isDebug,
       isAzureGov,
@@ -180,6 +190,13 @@ export class OpenBotDialog extends Component<OpenBotDialogProps, OpenBotDialogSt
               value={appPassword}
             />
           </Row>
+          <TextField
+            name="tenantId"
+            label="Tenant ID"
+            onChange={this.onInputChange}
+            placeholder="Optional"
+            value={tenantId}
+          />
           {!isDebug && (
             <Row className={openBotStyles.multiInputRow}>
               <TextField

--- a/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialogContainer.ts
+++ b/packages/app/client/src/ui/dialogs/openBotDialog/openBotDialogContainer.ts
@@ -50,6 +50,7 @@ const mapDispatchToProps = (dispatch: (action: Action) => void): OpenBotDialogPr
       const {
         appId = '',
         appPassword = '',
+        tenantId = '',
         botUrl = '',
         mode = 'livechat-url',
         isAzureGov,
@@ -63,6 +64,7 @@ const mapDispatchToProps = (dispatch: (action: Action) => void): OpenBotDialogPr
           openBotViaUrlAction({
             appId,
             appPassword,
+            tenantId,
             endpoint: botUrl,
             mode,
             channelService: isAzureGov ? 'azureusgovernment' : 'public',

--- a/packages/app/main/src/server/constants/authEndpoints.ts
+++ b/packages/app/main/src/server/constants/authEndpoints.ts
@@ -34,6 +34,7 @@
 export const authentication = {
   channelService: 'https://dev.botframework.com/',
   tokenEndpoint: 'https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token',
+  tokenEndpointSingleTenant: 'https://login.microsoftonline.com/{tenant-id}/oauth2/v2.0/token',
   openIdMetadata: 'https://login.microsoftonline.com/botframework.com/v2.0/.well-known/openid-configuration',
   botTokenAudience: 'https://api.botframework.com',
 };
@@ -53,6 +54,7 @@ export const v31Authentication = {
 };
 
 export const v32Authentication = {
+  tokenIssuerSingleTenant: 'https://sts.windows.net/{tenant-id}/',
   tokenIssuerV1: 'https://sts.windows.net/f8cdef31-a31e-4b4a-93e4-5f571e91255a/',
   tokenIssuerV2: 'https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a/v2.0',
 };

--- a/packages/app/main/src/server/routes/channel/conversations/handlers/getBotEndpoint.ts
+++ b/packages/app/main/src/server/routes/channel/conversations/handlers/getBotEndpoint.ts
@@ -45,7 +45,7 @@ export function createGetBotEndpointHandler(state: ServerState) {
     if (request.jwt && request.jwt.appid) {
       request.botEndpoint = endpoints.getByAppId(request.jwt.appid);
     } else {
-      const { bot, botUrl, channelServiceType, msaAppId, msaPassword, tenantId } = req.body;
+      const { bot, botUrl, channelServiceType, msaAppId, msaPassword, msaTenantId } = req.body;
       let endpoint = endpoints.get(botUrl);
       if (!endpoint) {
         const channelService =
@@ -55,12 +55,12 @@ export function createGetBotEndpointHandler(state: ServerState) {
         // create endpoint
         endpoint = endpoints.set(
           bot.id,
-          new BotEndpoint(bot.id, bot.id, botUrl, msaAppId, msaPassword, false, channelService, null, tenantId)
+          new BotEndpoint(bot.id, bot.id, botUrl, msaAppId, msaPassword, false, channelService, null, msaTenantId)
         );
       } else {
         endpoint.msaAppId = msaAppId;
         endpoint.msaPassword = msaPassword;
-        endpoint.tenantId = tenantId;
+        endpoint.tenantId = msaTenantId;
       }
       request.botEndpoint = endpoint;
     }

--- a/packages/app/main/src/server/routes/channel/conversations/handlers/getBotEndpoint.ts
+++ b/packages/app/main/src/server/routes/channel/conversations/handlers/getBotEndpoint.ts
@@ -45,22 +45,22 @@ export function createGetBotEndpointHandler(state: ServerState) {
     if (request.jwt && request.jwt.appid) {
       request.botEndpoint = endpoints.getByAppId(request.jwt.appid);
     } else {
-      const { bot, botUrl, channelServiceType, msaAppId, msaPassword } = req.body;
+      const { bot, botUrl, channelServiceType, msaAppId, msaPassword, tenantId } = req.body;
       let endpoint = endpoints.get(botUrl);
       if (!endpoint) {
         const channelService =
           channelServiceType === 'azureusgovernment'
             ? usGovernmentAuthentication.channelService
             : authentication.channelService;
-
         // create endpoint
         endpoint = endpoints.set(
           bot.id,
-          new BotEndpoint(bot.id, bot.id, botUrl, msaAppId, msaPassword, false, channelService)
+          new BotEndpoint(bot.id, bot.id, botUrl, msaAppId, msaPassword, false, channelService, null, tenantId)
         );
       } else {
         endpoint.msaAppId = msaAppId;
         endpoint.msaPassword = msaPassword;
+        endpoint.tenantId = tenantId;
       }
       request.botEndpoint = endpoint;
     }

--- a/packages/app/main/src/server/routes/channel/conversations/mountConversationsRoutes.ts
+++ b/packages/app/main/src/server/routes/channel/conversations/mountConversationsRoutes.ts
@@ -51,7 +51,7 @@ import { getActivitiesForConversation } from './handlers/getActivitiesForConvers
 
 export function mountConversationsRoutes(emulatorServer: EmulatorRestServer) {
   const { server, state } = emulatorServer;
-  const verifyBotFramework = createBotFrameworkAuthenticationMiddleware(emulatorServer.options.fetch);
+  const verifyBotFramework = createBotFrameworkAuthenticationMiddleware(emulatorServer.options.fetch, state);
   const jsonBodyParser = createJsonBodyParserMiddleware();
   const fetchConversation = createGetConversationHandler(state);
 

--- a/packages/app/main/src/server/routes/handlers/botFrameworkAuthentication.ts
+++ b/packages/app/main/src/server/routes/handlers/botFrameworkAuthentication.ts
@@ -41,13 +41,21 @@ import {
   v32Authentication,
 } from '../../constants/authEndpoints';
 import { OpenIdMetadata } from '../../utils/openIdMetadata';
+import { ConversationAPIPathParameters } from '../channel/conversations/types/conversationAPIPathParameters';
+import { ServerState } from '../../state/serverState';
 
-export function createBotFrameworkAuthenticationMiddleware(fetch: any) {
+export function createBotFrameworkAuthenticationMiddleware(fetch: any, state?: ServerState) {
   const openIdMetadata = new OpenIdMetadata(fetch, authentication.openIdMetadata);
   const usGovOpenIdMetadata = new OpenIdMetadata(fetch, usGovernmentAuthentication.openIdMetadata);
 
   return async (req: Restify.Request, res: Restify.Response) => {
     const authorization = req.header('Authorization');
+
+    const conversationParameters: ConversationAPIPathParameters = req.params;
+    let conversation;
+    if (conversationParameters?.conversationId && state) {
+      conversation = state.conversations.conversationById(conversationParameters.conversationId);
+    }
 
     if (!authorization) {
       return;
@@ -118,7 +126,9 @@ export function createBotFrameworkAuthenticationMiddleware(fetch: any) {
 
       let issuer;
 
-      if (decoded.payload.ver === '1.0') {
+      if (conversation?.botEndpoint.tenantId) {
+        issuer = v32Authentication.tokenIssuerSingleTenant.replace('{tenant-id}', conversation?.botEndpoint.tenantId);
+      } else if (decoded.payload.ver === '1.0') {
         issuer = v32Authentication.tokenIssuerV1;
       } else if (decoded.payload.ver === '2.0') {
         issuer = v32Authentication.tokenIssuerV2;

--- a/packages/app/main/src/server/state/endpointSet.ts
+++ b/packages/app/main/src/server/state/endpointSet.ts
@@ -57,7 +57,8 @@ export class EndpointSet {
       botEndpoint.channelService,
       {
         fetch: this._fetch,
-      }
+      },
+      botEndpoint.tenantId
     );
 
     this._endpoints[id] = botEndpointInstance;

--- a/packages/sdk/shared/src/emulatorApi/conversationService.ts
+++ b/packages/sdk/shared/src/emulatorApi/conversationService.ts
@@ -58,7 +58,7 @@ interface StartConversationPayload {
   mode: EmulatorMode;
   msaAppId?: string;
   msaPassword?: string;
-  tenantId?: string;
+  msaTenantId?: string;
 }
 
 export class ConversationService {

--- a/packages/sdk/shared/src/emulatorApi/conversationService.ts
+++ b/packages/sdk/shared/src/emulatorApi/conversationService.ts
@@ -58,6 +58,7 @@ interface StartConversationPayload {
   mode: EmulatorMode;
   msaAppId?: string;
   msaPassword?: string;
+  tenantId?: string;
 }
 
 export class ConversationService {

--- a/packages/sdk/shared/src/types/botEndpoint.ts
+++ b/packages/sdk/shared/src/types/botEndpoint.ts
@@ -36,6 +36,7 @@ export interface BotEndpoint {
   botUrl: string;
   msaAppId: string;
   msaPassword: string;
+  tenantId: string;
   use10Tokens?: boolean;
   channelService?: string;
 }

--- a/packages/sdk/shared/src/types/botEndpoint.ts
+++ b/packages/sdk/shared/src/types/botEndpoint.ts
@@ -36,7 +36,7 @@ export interface BotEndpoint {
   botUrl: string;
   msaAppId: string;
   msaPassword: string;
-  tenantId: string;
+  msaTenantId?: string;
   use10Tokens?: boolean;
   channelService?: string;
 }


### PR DESCRIPTION
Fixes # 2398

## Description
This PR adds the support to use the _**tenant id**_ value to authenticate Emulator into Single Tenant apps.
This feature requires bots with the las updates of botbuilder-dotnet and botbuilder-js:
PR # 321
PR # 123

## Specific Changes
  - Added **_tenantId_** property to the classes involved in authentication.
  - Added support to obtain access token through Single Tenant login endpoint.
  - Added method to use tenant id value to create a dynamic _**issuer**_.

## Testing
These images show the new field Tenant ID in the Open Bot and New Bot Configuration views. 
![image](https://github.com/southworks/BotFramework-Emulator/assets/122501764/76aad453-b6bc-4085-b234-17cd00bb85d6)
![image](https://github.com/southworks/BotFramework-Emulator/assets/122501764/476583cb-7e67-482c-8498-436015263263)

This is the new message error related to authentication.
![image](https://github.com/southworks/BotFramework-Emulator/assets/122501764/db00b5d0-9aff-47f8-ab39-c1556860f633)

The following image shows the Emulator working with a bot using Single Tenant authentication.
![image](https://github.com/southworks/botbuilder-dotnet/assets/122501764/cb8727f8-e76c-4942-830c-1ceae9eafb95)